### PR TITLE
Add reverse-string exercise with three solutions

### DIFF
--- a/ongoing/reverse-string/reverse_string.go
+++ b/ongoing/reverse-string/reverse_string.go
@@ -1,1 +1,32 @@
 package reverse
+
+// Uses runes to reverse a string
+//func Reverse(s string) string {
+//	n := len(s)
+//	runes := make([]rune, n)
+//	for _, rune := range s {
+//		n--
+//		runes[n] = rune
+//	}
+//	return string(runes[n:])
+//}
+
+
+//func Reverse(s string) string {
+//	size := len(s)
+//	buf := make([]byte, size)
+//	for start := 0; start < size; {
+//		r, n := utf8.DecodeRuneInString(s[start:])
+//		start += n
+//		utf8.EncodeRune(buf[size-start:], r)
+//	}
+//	return string(buf)
+//}
+
+// Reverse: This one seems to be the most efficient method
+func Reverse(s string) (result string) {
+	for _,v := range s {
+		result = string(v) + result
+	}
+	return
+}


### PR DESCRIPTION
Added three solutions;

The uncommented one seems to be the most efficient way of doing it.

I think I understand how it's working.


```yaml
=== RUN   TestReverse
--- PASS: TestReverse (0.00s)
        reverse_string_test.go:14: PASS: an empty string
        reverse_string_test.go:14: PASS: a word
        reverse_string_test.go:14: PASS: a capitalized word
        reverse_string_test.go:14: PASS: a sentence with punctuation
        reverse_string_test.go:14: PASS: a palindrome
        reverse_string_test.go:14: PASS: an even-sized word
        reverse_string_test.go:14: PASS: a multi-byte test case
=== RUN   TestReverseOfReverse
--- PASS: TestReverseOfReverse (0.00s)
goos: linux
goarch: amd64
BenchmarkReverse-16      1000000              1199 ns/op             176 B/op         34 allocs/op
PASS
ok      _/home/aaron/go-exercises/ongoing/reverse-string        1.220s
```